### PR TITLE
add Abusing JWT Public Keys Without knowing the Public Key

### DIFF
--- a/MindAPI.md
+++ b/MindAPI.md
@@ -231,6 +231,9 @@
 - [jwtcat](https://github.com/aress31/jwtcat)
 - [apicheck](https://github.com/BBVA/apicheck)
 
+###### Abusing JWT Public Keys Without knowing the Public Key
+- [rsa_sig2n](https://github.com/silentsignal/rsa_sign2n)
+
 ###### Test if algorithm could be changed
 - [jwt.io](https://jwt.io/#debugger-io)
 - [jwtcat](https://github.com/aress31/jwtcat)


### PR DESCRIPTION
Further info, check - https://blog.silentsignal.eu/2021/02/08/abusing-jwt-public-keys-without-the-public-key/ 