### PR TITLE
feat(bola): Add cross-deployment IDs

### DIFF
--- a/MindAPI.md
+++ b/MindAPI.md
@@ -187,6 +187,11 @@
 ###### Wildcard
 - GET /users/id -> GET /users/*
 
+###### cross-deployments IDs
+- Identify other deployments (hosts) of your target API
+- Enumerate resources IDs (often non- numerical/sequential ones)
+- Test those IDs on your target API host
+
 #### Check the response
 
 #### Tools


### PR DESCRIPTION
Let's say the target API is part of a commercial product.
Identifying other deployment of the same product may give you access to
resources IDs. You should test those IDs with your target API.

IDs may be hardcoded or predictable, being the same/valid across
deployments/instances of the same product.