### PR TITLE
feat(website): Download as interactive HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/public

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -37,6 +37,18 @@ googleAnalytics = ""
     name = "Play"
     weight = 4
 
+[[menu.main]]
+    url = "#download"
+    identifier = "download"
+    name = "Download"
+    weight = 5
+
+[[menu.main]]
+    parent = "download"
+    identifier = "interactive"
+    url = "#download-interactive"
+    name = "Interactive HTML"
+
 # Social icons to be shown on the right-hand side of the navigation bar.
 # The "name" field should match the name of the icon in Font Awesome.
 # The list of available icons can be found at http://fontawesome.io/icons.

--- a/docs/layouts/partials/header.html
+++ b/docs/layouts/partials/header.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+    <head>
+        {{ partial "head-open" . }}
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{{ .Title }}</title>
+        {{ if .Site.Params.favicon }}
+            <link rel="icon" href="{{ .Site.Params.favicon | absURL }}">
+        {{ end }}
+        {{ partial "css" . }} {{ partial "js" . }} {{ hugo.Generator }}
+        {{ with .OutputFormats.Get "RSS" }}
+            <link href="{{ .RelPermalink }}" rel="alternate" type="{{ .MediaType.Type }}" title="{{ $.Site.Title }}" />
+            <link href="{{ .RelPermalink }}" rel="feed" type="{{ .MediaType.Type }}" title="{{ $.Site.Title }}" />
+        {{ end }}
+
+        {{ if .Site.GoogleAnalytics }}
+            <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+            <script>
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments)};
+              gtag('js', new Date());
+              gtag('config', '{{ .Site.GoogleAnalytics }}');
+            </script>
+        {{ end }}
+
+        {{ if .Site.Params.MathJax | default true }}
+            <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        {{ end }}
+
+        {{ partial "head-close" . }}
+    </head>
+
+    <body>
+        {{ partial "body-open" . }}
+        <nav class="navbar navbar-default navbar-fixed-top">
+            <div class="container">
+                <div class="navbar-header">
+                    <a class="navbar-brand visible-xs" href="#">{{ .Title }}</a>
+                    <button class="navbar-toggle" data-target=".navbar-collapse" data-toggle="collapse">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+                <div class="collapse navbar-collapse">
+                    {{ if .Site.Menus.main }}
+                        <ul class="nav navbar-nav">
+                            {{ range sort .Site.Menus.main }}
+                                {{ if .HasChildren }}
+                                    <li role="presentation" class="dropdown">
+                                        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" href="{{ .URL }}">{{ .Name }}<span class="caret"></span></a>
+                                        <ul class="dropdown-menu">
+                                            {{ range .Children }}
+                                                <li><a id="{{ .Parent }}-{{ .Identifier }}" href="{{ .URL }}">{{ .Name }}</a></li>
+                                            {{ end }}
+                                        </ul>
+                                    </li>
+                                {{ else }}
+                                    <li>
+                                        <a href="{{ .URL }}">{{ .Name }}</a>
+                                    </li>
+                                {{ end }}
+                            {{ end }}
+                        </ul>
+                    {{ end }}
+                    {{ if .Site.Menus.icon }}
+                        <ul class="nav navbar-nav navbar-right">
+                            {{ range sort .Site.Menus.icon }}
+                                <li class="navbar-icon"><a href="{{ .URL }}"><i class="{{ .Name }}"></i></a></li>
+                            {{ end }}
+                        </ul>
+                    {{ end }}
+                </div>
+            </div>
+        </nav>

--- a/docs/layouts/section/play.html
+++ b/docs/layouts/section/play.html
@@ -6,19 +6,30 @@
   <script src="https://cdn.jsdelivr.net/npm/markmap-lib@0.11.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/markmap-view@0.2.6"></script>
   <script>
-    (async () => {
+    (async (d) => {
       const a = 'https://raw.githubusercontent.com/dsopas/MindAPI/main/MindAPI.md';
+
       try {
         const b = await fetch(a),
               c = await b.text(),
               t = new markmap.Transformer;
 
-        const { root } = t.transform(c);
+        const { root, features } = t.transform(c);
         markmap.Markmap.create("#mindmap", null, root);
+
+        d.getElementById('download-interactive').addEventListener('click', () => {
+          const r = t.getUsedAssets(features),
+                i = markmap.fillTemplate(root,r);
+
+          anchor = d.createElement('a');
+          anchor.setAttribute('href', 'data:text/html;utf8,' + encodeURIComponent(i));
+          anchor.setAttribute('download', 'mindapi.html');
+          anchor.click();
+        });
       } catch (a) {
         console.error(a)
       }
-    })()
+    })(document);
   </script>
 </main>
 

--- a/docs/layouts/section/play.html
+++ b/docs/layouts/section/play.html
@@ -2,21 +2,23 @@
 
 <main id="markmap">
   <svg id="mindmap"></svg>
-  <script src="https://cdn.jsdelivr.net/npm/d3@5"></script>
-  <script src="https://cdn.jsdelivr.net/npm/markmap-lib@0.7.11/dist/browser/view.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/markmap-lib@0.7.11/dist/browser/transform.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markmap-lib@0.11.6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markmap-view@0.2.6"></script>
   <script>
     (async () => {
-      const URL = 'https://raw.githubusercontent.com/dsopas/MindAPI/main/MindAPI.md';
+      const a = 'https://raw.githubusercontent.com/dsopas/MindAPI/main/MindAPI.md';
       try {
-        const response = await fetch(URL);
-        const markdown = await response.text();
-        const data = markmap.transform(markdown);
-        markmap.Markmap.create("#mindmap", null, data);
-      } catch (e) {
-        console.error(e);
+        const b = await fetch(a),
+              c = await b.text(),
+              t = new markmap.Transformer;
+
+        const { root } = t.transform(c);
+        markmap.Markmap.create("#mindmap", null, root);
+      } catch (a) {
+        console.error(a)
       }
-    })();
+    })()
   </script>
 </main>
 


### PR DESCRIPTION
This PR adds a "Download as interactive HTML" feature to MindAPI website.

Dependencies (`d3`, `markmap-lib`, and `markmap-view`) were updated.