### PR TITLE
feat(tools): Add graphql-path-enum

### DIFF
--- a/MindAPI.md
+++ b/MindAPI.md
@@ -242,6 +242,7 @@
   - [Susanoo](https://github.com/ant4g0nist/Susanoo)
 - GraphQL
   - [InQL](https://github.com/doyensec/inql)
+  - [graphql-path-enum](https://gitlab.com/dee-see/graphql-path-enum)
 - gRPC-protobuf
   - [ProtoFuzz](https://github.com/trailofbits/protofuzz)
 


### PR DESCRIPTION
Based on GraphQL introspection, graphql-path-enum, may help to find
alternative paths to access a specific type, bypassing authorization
checks.